### PR TITLE
Fixed WeChat naming and hyperlink spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <img src=resources/logo.svg width="15%"/>
 </div>
 <p align="center">
-    👋 Join our <a href="resources/WECHAT.md" target="_blank">Wechat</a> or <a href="https://discord.gg/QR7SARHRxK" target="_blank">Discord</a> community.
+    👋 Join our <a href="resources/WECHAT.md" target="_blank">WeChat</a> or <a href="https://discord.gg/QR7SARHRxK" target="_blank">Discord</a> community.
     <br>
     📖 Check out the GLM-5 <a href="https://z.ai/blog/glm-5" target="_blank">technical blog</a>.
     <br>


### PR DESCRIPTION
This just changes "Wechat" to "WeChat" which is the correct way to write it and also fixed a spacing issue in the hyperlink for WeChat. 