### PR TITLE
docs: remove double-space typo before links in example/ascend.md

### DIFF
--- a/example/ascend.md
+++ b/example/ascend.md
@@ -12,11 +12,11 @@ Currently, the Ascend platform already supports the deployment of GLM-5.2. Effic
 
 # vLLM
 
-This  [vLLM-Ascend](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/GLM5.2.html) document demonstrates how to deploy GLM-5.2 on vLLM using the vLLM-Ascend plugin. It shows the main verification steps of the model, including supported features, feature configuration, environment preparation, single-node and multi-node deployment, Prefill-Decode disaggregation, accuracy and performance evaluation.
+This [vLLM-Ascend](https://docs.vllm.ai/projects/ascend/en/latest/tutorials/models/GLM5.2.html) document demonstrates how to deploy GLM-5.2 on vLLM using the vLLM-Ascend plugin. It shows the main verification steps of the model, including supported features, feature configuration, environment preparation, single-node and multi-node deployment, Prefill-Decode disaggregation, accuracy and performance evaluation.
 
 # SGLang
 
-This  [sgLang](https://github.com/sgl-project/sglang/blob/main/docs_new/docs/hardware-platforms/ascend-npus/ascend_npu_glm5.2_examples.mdx) document demonstrates how to deploy GLM-5.2 on sglang. It shows the main verification steps of the model, including supported features, feature configuration, environment preparation, single-node and multi-node deployment, accuracy and performance evaluation.
+This [sgLang](https://github.com/sgl-project/sglang/blob/main/docs_new/docs/hardware-platforms/ascend-npus/ascend_npu_glm5.2_examples.mdx) document demonstrates how to deploy GLM-5.2 on sglang. It shows the main verification steps of the model, including supported features, feature configuration, environment preparation, single-node and multi-node deployment, accuracy and performance evaluation.
 
 # xLLM
 


### PR DESCRIPTION
## Summary

Fixes a small but visible typo in \`example/ascend.md\`: two sentences begin with a double space before the markdown link (`` ``This  [link]`` ``). This collapses the stray double space to a single space in both spots.

## Changes

- \`example/ascend.md\` line 15: ``This  [vLLM-Ascend]...`` → ``This [vLLM-Ascend]...``
- \`example/ascend.md\` line 19: ``This  [sgLang]...`` → ``This [sgLang]...``

Net diff: 1 file changed, 2 insertions(+), 2 deletions(-) — only whitespace removed, no link targets or wording changed.

## Verification

- Confirmed the double-space pattern (`` {2,}\[``) appears nowhere else in the repo after the fix.
- Verified both link URLs are unchanged.

## Type

- [x] This PR fixes a typo or improves the documentation (per the repo's contribution guide, the other checks may be skipped for this case).

