### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GLM-5.2 & GLM-5.1 & GLM-5
 
+[![Listed on TakoAPI](https://takoapi.com/api/badge/zai-org-glm-5)](https://takoapi.com/agents/zai-org-glm-5)
+
 <div align="center">
 <img src=resources/logo.svg width="15%"/>
 </div>


### PR DESCRIPTION
Hi! 👋 **GLM-5** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/zai-org-glm-5

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building GLM-5! 🙏