### PR TITLE
docs: correct Transformers minimum version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The GLM-5 series supports deployment with the following frameworks. Feel free to
 
 - [SGLang](https://github.com/sgl-project/sglang) (v0.5.13.post1+) — see [cookbook](https://cookbook.sglang.io/autoregressive/GLM/GLM-5.2)
 - [vLLM](https://github.com/vllm-project/vllm) (v0.23.0+) — see [recipes](https://recipes.vllm.ai/zai-org/GLM-5.2)
-- [Transformers](https://github.com/huggingface/transformers) (v0.5.12+) — see [transformers docs](https://github.com/huggingface/transformers/blob/main/docs/source/en/model_doc/glm_moe_dsa.md)
+- [Transformers](https://github.com/huggingface/transformers) (v5.15.0+) — see [transformers docs](https://github.com/huggingface/transformers/blob/main/docs/source/en/model_doc/glm_moe_dsa.md)
 - [KTransformers](https://github.com/kvcache-ai/ktransformers) (v0.5.12+) — see [tutorial](https://github.com/kvcache-ai/ktransformers/blob/main/doc/en/kt-kernel/GLM-5.2-Tutorial.md)
 - [Unsloth](https://github.com/unslothai/unsloth) (v0.1.47-beta+) — see [guide](https://unsloth.ai/docs/models/glm-5.2)
 - For deployment on the `Ascend NPU` platform, inference frameworks such as vLLM-Ascend, xLLM and SGLang are supported — see [here](example/ascend.md).

--- a/README_zh.md
+++ b/README_zh.md
@@ -73,7 +73,7 @@ GLM-5 系列支持使用以下多种框架部署，欢迎尝试：
 
 - [SGLang](https://github.com/sgl-project/sglang) (v0.5.13.post1+) — 参见 [cookbook](https://cookbook.sglang.io/autoregressive/GLM/GLM-5.2)
 - [vLLM](https://github.com/vllm-project/vllm) (v0.23.0+) — 参见 [recipes](https://recipes.vllm.ai/zai-org/GLM-5.2)
-- [Transformers](https://github.com/huggingface/transformers) (v0.5.12+) — 参见 [transformers docs](https://github.com/huggingface/transformers/blob/main/docs/source/en/model_doc/glm_moe_dsa.md)
+- [Transformers](https://github.com/huggingface/transformers) (v5.15.0+) — 参见 [transformers docs](https://github.com/huggingface/transformers/blob/main/docs/source/en/model_doc/glm_moe_dsa.md)
 - [KTransformers](https://github.com/kvcache-ai/ktransformers) (v0.5.12+) — 参见 [tutorial](https://github.com/kvcache-ai/ktransformers/blob/main/doc/en/kt-kernel/GLM-5.2-Tutorial.md)
 - [Unsloth](https://github.com/unslothai/unsloth) (v0.1.47-beta+) — 参见 [guide](https://unsloth.ai/docs/models/glm-5.2)
 - 在 `Ascend NPU` 平台上部署时，支持 vLLM-Ascend、xLLM 、SGLang 等推理框架，参见 [这里](example/ascend.md)


### PR DESCRIPTION
The Transformers entry in the local-serving list reads `(v0.5.12+)`, the same version string as the neighboring KTransformers line. Transformers has no 0.5.x release, and this repo's own `requirements.txt` pins `transformers>=5.15.0`.

This updates the Transformers line to `(v5.15.0+)` in README.md and README_zh.md. The KTransformers line is untouched, `v0.5.12+` is plausible for that project's own versioning.
